### PR TITLE
updated goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
-      - name: Install stuffbin
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.17
-        run: go install github.com/knadh/stuffbin/stuffbin@latest
+      - run: go install github.com/knadh/stuffbin/stuffbin@latest
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -30,4 +26,4 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Install stuffbin
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+        run: go install github.com/knadh/stuffbin/stuffbin@latest
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,12 +54,12 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
-# brews:
-#   - name: hopp-cli
-#     github:
-#       owner: athul
-#       name: homebrew-tap
-#     folder: Formula
-#     homepage: "https://github.com/hoppscotch/hopp-cli"
-#     description: "CLI for Hoppscotch.io"
-#     install: bin.install "hopp-cli"
+brews:
+  - name: hopp-cli
+    github:
+      owner: athul
+      name: homebrew-tap
+    folder: Formula
+    homepage: "https://github.com/hoppscotch/hopp-cli"
+    description: "CLI for Hoppscotch.io"
+    install: bin.install "hopp-cli"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,16 @@
+project_name: hopp-cli
+release:
+  github:
+    owner: hoppscotch
+    name: hopp-cli
+  prerelease: auto
+  draft: false
+  name_template: "hopp-cli {{.Version}}"
+before:
+  hooks:
+    - go mod tidy
 env:
-  - RELEASE_BUILDS=dist/hopp-cli_darwin_amd64/hopp-cli dist/hopp-cli_linux_386/hopp-cli dist/hopp-cli_linux_amd64/hopp-cli dist/hopp-cli_windows_386/hopp-cli.exe dist/hopp-cli_windows_amd64/hopp-cli.exe
+  - RELEASE_BUILDS=dist/hopp-cli_darwin_amd64/hopp-cli dist/hopp-cli_darwin_arm64/hopp-cli dist/hopp-cli_linux_386/hopp-cli dist/hopp-cli_linux_amd64/hopp-cli dist/hopp-cli_windows_386/hopp-cli.exe dist/hopp-cli_windows_amd64/hopp-cli.exe
 builds:
   - env:
       - CGO_ENABLED=0
@@ -29,29 +40,26 @@ builds:
         goarch: 386
 archives:
   - replacements:
-      darwin: Darwin
-      linux: Linux
+      darwin: macOS
+      386: i386
+      linux: linux
       amd64: x86_64
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
-  name_template: '{{ .Tag }}'
+  name_template: "{{ .Tag }}"
 changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
-release:
-  github:
-    owner: hoppscotch
-    name: hopp-cli
-brews:
-  - name: hopp-cli
-    github:
-      owner: athul
-      name: homebrew-tap
-    folder: Formula
-    homepage: 'https://github.com/hoppscotch/hopp-cli'
-    description: 'CLI for Hoppscotch.io'
-    install: bin.install "hopp-cli"
+      - "^docs:"
+      - "^test:"
+# brews:
+#   - name: hopp-cli
+#     github:
+#       owner: athul
+#       name: homebrew-tap
+#     folder: Formula
+#     homepage: "https://github.com/hoppscotch/hopp-cli"
+#     description: "CLI for Hoppscotch.io"
+#     install: bin.install "hopp-cli"

--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,4 @@ uninstall:
 
 .PHONY: pack-releases
 pack-releases:
-	$(foreach var,$(RELEASE_BUILDS),stuffbin -a stuff -in ${var} -out ${var} ${STATIC};)
+	$(foreach var,$(RELEASE_BUILDS),stuffbin -a stuff -in ${var} -out ./${var} ${STATIC};)


### PR DESCRIPTION
* continued from PR #48
* added support for arm64 build
* added github actions worflow (set `GH_TOKEN` as repo secret)
* added workflow for using github actions, works only on a tag:

1. Push to branch
2. Create tag (`git tag create -a vX.X.X -m "info about tag"`)
3. git push origin {tag}

    This will run the action